### PR TITLE
Relax encoding regex

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,7 +43,7 @@ class EPUBBook {
   // Add UTF-8 encoding declaration if missing
   fixEncoding() {
     const encoding = '<?xml version="1.0" encoding="utf-8"?>'
-    const regex = /^<\?xml\s+version=["'][\d.]+["']\s+encoding=["'][a-zA-Z\d-.]+["'].*\?>/i
+    const regex = /^<\?xml\s+version=["'][\d.]+["']\s+encoding=["'][a-zA-Z\d-.]+["'].*?\?>/i
 
     for (const filename in this.files) {
       const ext = filename.split('.').pop()

--- a/script.js
+++ b/script.js
@@ -43,7 +43,7 @@ class EPUBBook {
   // Add UTF-8 encoding declaration if missing
   fixEncoding() {
     const encoding = '<?xml version="1.0" encoding="utf-8"?>'
-    const regex = /^<\?xml\s+version=["'][\d.]+["']\s+encoding=["'][a-zA-Z\d-.]+["']\s*\?>/i
+    const regex = /^<\?xml\s+version=["'][\d.]+["']\s+encoding=["'][a-zA-Z\d-.]+["'].*\?>/i
 
     for (const filename in this.files) {
       const ext = filename.split('.').pop()


### PR DESCRIPTION
I had an epub which was using additional attributes in the `xml` tag (in my case it was `<?xml version="1.0" encoding="UTF-8" standalone="no"?>`). The regex wasn’t matching it and therefore the script added an additional `xml` tag which made the file invalid. 

Since we don’t care if there are any additional attributes, this change relaxes the regex so it matches tags like the above. 

Thanks for the super-handy tool! I use it all the time.