### PR TITLE
Added option to retain original filename when downloading .epubs

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
 
     <h2>Select your EPUB</h2>
     <form>
+        <label for="keepOriginalFilename">Keep original filename</label>
+        <input id="keepOriginalFilename" type="checkbox">    
         <input id="file" type="file" accept=".epub" multiple>
         <small>Multiple files allowed.</small>
     </form>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ const TXT_SYS_ERROR = 'The program encountered an internal error.'
 const mainStatusDiv = document.getElementById('main_status')
 const outputDiv = document.getElementById('output')
 const btnDlAll = document.getElementById('btnDlAll')
+const keepOriginalFilename = document.getElementById('keepOriginalFilename')
 
 const filePicker = document.getElementById('file')
 
@@ -300,10 +301,10 @@ async function processEPUB (inputBlob, name) {
     fixedBlobs.push(blob)
 
     if (epub.fixedProblems.length > 0) {
-      dlfilenames.push("(fixed) " + name)
+      keepOriginalFilename.checked ? dlfilenames.push(name) : dlfilenames.push("(fixed) " + name)
       outputDiv.appendChild(build_output_html(idx, epub.fixedProblems))
     } else {
-      dlfilenames.push("(repacked) " + name)
+      keepOriginalFilename.checked ? dlfilenames.push(name) : dlfilenames.push("(repacked) " + name)
       outputDiv.appendChild(build_output_html(idx, TXT_NO_ERROR))
     }
   } catch (e) {


### PR DESCRIPTION
As there was a feature request for this, I thought I'd add a checkbox to handle removing the (repacked) or (fixed) text from filenames.

1. Added a checkbox to toggle user preference to retain original filename in index.html
2. Updated processEPUB function to conditionally check the value of the checkbox to adjust output filename accordingly.

