### PR TITLE
Added viewport meta tag for better mobile scaling and hide version summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Amazon Kindle EPUB Fix</title>
     <script src="https://unpkg.com/@zip.js/zip.js@2.6.12/dist/zip.min.js"></script>
     <script src="https://unpkg.com/file-saver@2.0.5/dist/FileSaver.min.js"></script>
@@ -63,8 +64,8 @@
     <div id="output"></div>
 
     <hr style="margin:1em 0">
-
-    <h2>Version History</h2>
+    <details>
+    <summary>Version History</summary>
 
     <ul>
         <li>
@@ -100,7 +101,7 @@
             Initial release.
         </li>
     </ul>
-
+</details>
     <p>Source code is available on <a href="https://github.com/innocenat/kindle-epub-fix" rel="noopener"
             target="_blank">GitHub.</a></p>
 


### PR DESCRIPTION
The `<meta name="viewport" content="width=device-width, initial-scale=1.0">` tag was missing from the document head. 

The page renders with better scaling on mobile devices, when this tag included.

I also wrapped the version history in a details tag.