### PR TITLE
Additional E999 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
-# Kindle EPUB Fix
+# Kindle EPUB Fix (Enhanced Fork)
 
-Amazon Send-to-Kindle service has accepted EPUB, however, for historical reason
-it still assumes ISO-8859-1 encoding if no encoding is specified. This creates weird formatting errors for special characters.
+Amazon Send-to-Kindle service accepts EPUB files, but is strict about validation and encoding. This tool fixes common issues that cause E999 and E21018 errors.
 
-This tool will try to fix your EPUB by adding the UTF-8 specification to your EPUB. It currently does
-not fix other errors.
+**Use it now:** https://deploy-preview-25--kindle-epub-fix.netlify.app/
 
-You can access this tools at https://kindle-epub-fix.netlify.app
+## What This Tool Fixes
 
-**Warning:** This tool come at no warranty. Please still keep your original EPUB.
-We don't guarantee the resulting file will be valid EPUB file, but it should.
+- **Encoding:** Adds UTF-8 declaration if missing
+- **E21018 errors:** Removes empty `alt=""` attributes and `data-AmznRemoved` attributes
+- **Hyperlinks:** Fixes NCX table of contents links to `<body>` with ID hash
+- **Language:** Detects invalid/missing language tags, prompts for correction
+- **Stray images:** Removes `<img>` tags with no source
+- **Unique identifier:** Fixes mismatch between OPF package and dc:identifier
+- **NCX playOrder:** Ensures sequential numbering
+- **Smart quotes:** Normalizes unicode quotes/dashes in NCX navigation to ASCII
+- **EPUB3 attributes:** Removes `epub:type`, `epub:prefix`, `xmlns:epub` (not supported by older Kindle)
+- **Bold/Italic tags:** Converts `<b>`, `<strong>`, `<i>`, `<em>` to CSS-styled `<span>` elements
+- **Scripts:** Removes `<script>` tags
+- **OPF metadata:** Cleans up `primary-writing-mode` and other problematic metadata
 
+## Privacy
+
+The book is processed entirely in your browser. Nothing is uploaded.
+
+## Debugging Tip
+
+If your EPUB still fails after processing, use [Kindle Previewer](https://www.amazon.com/Kindle-Previewer/b?node=21381691011) to open it. It shows detailed error codes (like E21018) that help identify remaining issues.
+
+## Warning
+
+This tool comes with no warranty. Please keep your original EPUB. We do not guarantee the resulting file will be valid, but it should work with Send to Kindle.
+
+---
+
+*Enhanced fork of [innocenat/kindle-epub-fix](https://github.com/innocenat/kindle-epub-fix)*

--- a/index.html
+++ b/index.html
@@ -25,15 +25,23 @@
         It is also pretty strict when it comes to EPUB format validation.
     </p>
     <p>
-        This tool will try to fix your EPUB to be able to use with Send to Kindle. 
-        It currently tries to fix these problems:
+        This tool will try to fix your EPUB to be able to use with Send to Kindle.
+        It fixes these problems:
     </p>
     <ul>
         <li>Fix UTF-8 encoding problem by adding UTF-8 declaration if no encoding is specified</li>
-        <li>Fix hyperlink problem (result in Amazon rejecting the EPUB) when NCX table of content link to &lt;body&gt;
-            with ID hash.</li>
-        <li>Detect invalid and/or missing language tag in metadata, and prompt user to select new language.</li>
-        <li>Remove stray &lt;img&gt; tags with no source field.</li>
+        <li>Fix hyperlink problem when NCX table of contents links to &lt;body&gt; with ID hash</li>
+        <li>Detect invalid and/or missing language tag in metadata, and prompt user to select new language</li>
+        <li>Remove stray &lt;img&gt; tags with no source field</li>
+        <li>Remove empty alt="" attributes that cause E21018 parsing errors</li>
+        <li>Remove data-AmznRemoved attributes that cause kindlegen rejection</li>
+        <li>Fix unique-identifier mismatch between package and dc:identifier</li>
+        <li>Fix NCX playOrder sequence numbering</li>
+        <li>Normalize smart quotes and special characters in NCX navigation</li>
+        <li>Remove EPUB3-only attributes (epub:type, epub:prefix, xmlns:epub)</li>
+        <li>Convert &lt;b&gt;/&lt;strong&gt;/&lt;i&gt;/&lt;em&gt; to CSS-styled &lt;span&gt; elements</li>
+        <li>Remove &lt;script&gt; tags</li>
+        <li>Clean up OPF metadata (remove primary-writing-mode)</li>
     </ul>
     <p>
         <b>Privacy:</b> The book is processed locally in your browser. We do not upload your file anywhere.
@@ -44,6 +52,11 @@
     </p>
     <p>
         <b>Useful Tool: </b> <b><a href="https://ktool.io?ref=kindle-epub-fix">KTool.io</a></b> &mdash; Send web articles, newsletters & RSS feeds to Kindle
+    </p>
+    <p>
+        <b>Debugging Tip:</b> If your EPUB still fails after processing, download
+        <a href="https://www.amazon.com/Kindle-Previewer/b?node=21381691011" rel="noopener" target="_blank">Kindle Previewer</a>
+        and open the EPUB there. It shows detailed error codes (like E21018) that help identify remaining issues.
     </p>
 
     <h2>Select your EPUB</h2>
@@ -67,6 +80,17 @@
     <h2>Version History</h2>
 
     <ul>
+        <li>
+            <strong>2.0 - Jan 8, 2026 (Enhanced Fork)</strong><br>
+            Fix E21018 errors: remove empty alt="" and data-AmznRemoved attributes<br>
+            Fix unique-identifier mismatch in OPF<br>
+            Fix NCX playOrder sequence<br>
+            Normalize smart quotes in NCX navigation<br>
+            Remove EPUB3-only attributes (epub:type, xmlns:epub)<br>
+            Convert b/strong/i/em to CSS-styled spans<br>
+            Remove script tags and clean OPF metadata<br>
+            Preserve well-formed XHTML structure (regex-based fixes)
+        </li>
         <li>
             <strong>1.3 - Jan 4, 2023</strong><br>
             Batch processing<br>
@@ -101,8 +125,9 @@
         </li>
     </ul>
 
-    <p>Source code is available on <a href="https://github.com/innocenat/kindle-epub-fix" rel="noopener"
-            target="_blank">GitHub.</a></p>
+    <p>Source code is available on <a href="https://github.com/zglate/kindle-epub-fix" rel="noopener"
+            target="_blank">GitHub</a> (forked from <a href="https://github.com/innocenat/kindle-epub-fix" rel="noopener"
+            target="_blank">innocenat/kindle-epub-fix</a>).</p>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,30 @@ const TXT_DONE = 'Finished processing all files.'
 const TXT_NO_ERROR = 'No errors detected. Perhaps there are other errors?<br>Output file is available for download anyway.'
 const TXT_SYS_ERROR = 'The program encountered an internal error.'
 
+// Unicode to ASCII transliteration map for NCX/metadata
+const UNICODE_MAP = {
+  '\u201c': '"',  // left double quotation mark
+  '\u201d': '"',  // right double quotation mark
+  '\u2018': "'",  // left single quotation mark
+  '\u2019': "'",  // right single quotation mark (apostrophe)
+  '\u201a': "'",  // single low-9 quotation mark
+  '\u201b': "'",  // single high-reversed-9 quotation mark
+  '\u201e': '"',  // double low-9 quotation mark
+  '\u201f': '"',  // double high-reversed-9 quotation mark
+  '\u2013': '-',  // en dash
+  '\u2014': '--', // em dash
+  '\u2015': '--', // horizontal bar
+  '\u2026': '...', // ellipsis
+  '\u00a0': ' ',  // non-breaking space
+  '\u2002': ' ',  // en space
+  '\u2003': ' ',  // em space
+  '\u2009': ' ',  // thin space
+  '\u00ab': '"',  // left-pointing double angle quotation mark
+  '\u00bb': '"',  // right-pointing double angle quotation mark
+  '\u2039': "'",  // single left-pointing angle quotation mark
+  '\u203a': "'",  // single right-pointing angle quotation mark
+}
+
 const mainStatusDiv = document.getElementById('main_status')
 const outputDiv = document.getElementById('output')
 const btnDlAll = document.getElementById('btnDlAll')
@@ -219,6 +243,468 @@ class EPUBBook {
     }
   }
 
+  // Get the OPF filename from container.xml
+  getOPFFilename() {
+    if (!('META-INF/container.xml' in this.files)) {
+      return null
+    }
+    const parser = new DOMParser()
+    const container = parser.parseFromString(this.files['META-INF/container.xml'], 'application/xml')
+    for (const rootfile of container.getElementsByTagName('rootfile')) {
+      if (rootfile.getAttribute('media-type') === 'application/oebps-package+xml') {
+        return rootfile.getAttribute('full-path')
+      }
+    }
+    return null
+  }
+
+  // Ensure package@unique-identifier matches a dc:identifier id
+  fixUniqueIdentifier() {
+    const opfFilename = this.getOPFFilename()
+    if (!opfFilename || !(opfFilename in this.files)) {
+      console.error('Cannot find OPF file')
+      return
+    }
+
+    const parser = new DOMParser()
+    const opf = parser.parseFromString(this.files[opfFilename], 'application/xml')
+
+    // Check for parse error
+    if (opf.querySelector('parsererror')) {
+      console.error('OPF parse error')
+      return
+    }
+
+    const pkg = opf.documentElement
+    if (pkg.tagName !== 'package') {
+      console.error('OPF root is not <package>')
+      return
+    }
+
+    let uniqueIdAttr = pkg.getAttribute('unique-identifier')
+    const DC_NS = 'http://purl.org/dc/elements/1.1/'
+    const identifiers = opf.getElementsByTagNameNS(DC_NS, 'identifier')
+
+    if (identifiers.length === 0) {
+      // No dc:identifier at all - create one
+      const metadata = opf.getElementsByTagName('metadata')[0]
+      if (metadata) {
+        const newId = opf.createElementNS(DC_NS, 'dc:identifier')
+        const idValue = uniqueIdAttr || 'BookId'
+        newId.setAttribute('id', idValue)
+        newId.textContent = 'urn:uuid:' + crypto.randomUUID()
+        metadata.appendChild(newId)
+        if (!uniqueIdAttr) {
+          pkg.setAttribute('unique-identifier', idValue)
+        }
+        this.files[opfFilename] = new XMLSerializer().serializeToString(opf)
+        this.fixedProblems.push('Created missing dc:identifier')
+      }
+      return
+    }
+
+    // Check if unique-identifier matches any dc:identifier id
+    let matchFound = false
+    for (const id of identifiers) {
+      if (id.getAttribute('id') === uniqueIdAttr) {
+        matchFound = true
+        break
+      }
+    }
+
+    if (!matchFound) {
+      // No match - fix it
+      const firstId = identifiers[0]
+      const existingIdAttr = firstId.getAttribute('id')
+
+      if (existingIdAttr) {
+        // Update package to point to existing identifier
+        pkg.setAttribute('unique-identifier', existingIdAttr)
+        this.fixedProblems.push(`Fixed unique-identifier to match "${existingIdAttr}"`)
+      } else {
+        // Add id to first identifier
+        const newIdAttr = uniqueIdAttr || 'BookId'
+        firstId.setAttribute('id', newIdAttr)
+        if (!uniqueIdAttr) {
+          pkg.setAttribute('unique-identifier', newIdAttr)
+        }
+        this.fixedProblems.push('Added id attribute to dc:identifier')
+      }
+      this.files[opfFilename] = new XMLSerializer().serializeToString(opf)
+    }
+  }
+
+  // Find the NCX filename from the OPF manifest
+  getNCXFilename() {
+    const opfFilename = this.getOPFFilename()
+    if (!opfFilename || !(opfFilename in this.files)) {
+      return null
+    }
+
+    const parser = new DOMParser()
+    const opf = parser.parseFromString(this.files[opfFilename], 'application/xml')
+
+    // Look for NCX in manifest
+    const manifestItems = opf.getElementsByTagName('item')
+    for (const item of manifestItems) {
+      const mediaType = item.getAttribute('media-type')
+      const href = item.getAttribute('href')
+      if (mediaType === 'application/x-dtbncx+xml' && href) {
+        // Resolve relative to OPF location
+        const opfDir = opfFilename.includes('/') ? opfFilename.substring(0, opfFilename.lastIndexOf('/') + 1) : ''
+        return opfDir + href
+      }
+    }
+
+    // Fallback: look for .ncx file directly
+    for (const filename in this.files) {
+      if (filename.endsWith('.ncx')) {
+        return filename
+      }
+    }
+
+    return null
+  }
+
+  // Fix NCX playOrder to be sequential
+  fixNCXPlayOrder() {
+    const ncxFilename = this.getNCXFilename()
+    if (!ncxFilename || !(ncxFilename in this.files)) {
+      // No NCX file - EPUB3 might only have nav.xhtml
+      return
+    }
+
+    const parser = new DOMParser()
+    const ncx = parser.parseFromString(this.files[ncxFilename], 'application/xml')
+
+    // Check for parse error
+    if (ncx.querySelector('parsererror')) {
+      console.error('NCX parse error')
+      return
+    }
+
+    // Get all navPoints in document order
+    const navPoints = ncx.getElementsByTagName('navPoint')
+    if (navPoints.length === 0) {
+      return
+    }
+
+    // Check if playOrder needs fixing
+    let needsFix = false
+    let expectedOrder = 1
+    for (const np of navPoints) {
+      const currentOrder = parseInt(np.getAttribute('playOrder'), 10)
+      if (isNaN(currentOrder) || currentOrder !== expectedOrder) {
+        needsFix = true
+        break
+      }
+      expectedOrder++
+    }
+
+    if (needsFix) {
+      // Renumber all playOrder attributes sequentially
+      let order = 1
+      for (const np of navPoints) {
+        np.setAttribute('playOrder', order++)
+      }
+      this.files[ncxFilename] = new XMLSerializer().serializeToString(ncx)
+      this.fixedProblems.push('Fixed NCX playOrder sequence')
+    }
+  }
+
+  // Helper to transliterate unicode to ASCII
+  transliterateUnicode(text) {
+    let result = text
+    for (const [unicode, ascii] of Object.entries(UNICODE_MAP)) {
+      result = result.split(unicode).join(ascii)
+    }
+    return result
+  }
+
+  // Normalize unicode in NCX navLabel text
+  normalizeNCXUnicode() {
+    const ncxFilename = this.getNCXFilename()
+    if (!ncxFilename || !(ncxFilename in this.files)) {
+      return
+    }
+
+    const parser = new DOMParser()
+    const ncx = parser.parseFromString(this.files[ncxFilename], 'application/xml')
+
+    if (ncx.querySelector('parsererror')) {
+      return
+    }
+
+    let modified = false
+
+    // Find all text elements within navLabel
+    const textElements = ncx.getElementsByTagName('text')
+    for (const textEl of textElements) {
+      const original = textEl.textContent
+      const normalized = this.transliterateUnicode(original)
+      if (normalized !== original) {
+        textEl.textContent = normalized
+        modified = true
+      }
+    }
+
+    // Also normalize docTitle
+    const docTitles = ncx.getElementsByTagName('docTitle')
+    for (const dt of docTitles) {
+      const textEls = dt.getElementsByTagName('text')
+      for (const textEl of textEls) {
+        const original = textEl.textContent
+        const normalized = this.transliterateUnicode(original)
+        if (normalized !== original) {
+          textEl.textContent = normalized
+          modified = true
+        }
+      }
+    }
+
+    if (modified) {
+      this.files[ncxFilename] = new XMLSerializer().serializeToString(ncx)
+      this.fixedProblems.push('Normalized unicode characters in NCX')
+    }
+  }
+
+  // Apply fixes to HTML/XHTML files using regex to preserve original structure
+  // Only falls back to DOM parsing for malformed files
+  reserializeHTML() {
+    const parser = new DOMParser()
+
+    for (const filename in this.files) {
+      const ext = filename.split('.').pop().toLowerCase()
+      if (!['html', 'xhtml', 'htm'].includes(ext)) {
+        continue
+      }
+
+      let content = this.files[filename]
+      let modified = false
+      let fixes = []
+
+      // Try parsing as XHTML to check if well-formed
+      const strictDoc = parser.parseFromString(content, 'application/xhtml+xml')
+      const isMalformed = !!strictDoc.querySelector('parsererror')
+
+      if (isMalformed) {
+        // Malformed - need DOM round-trip via HTML5 parser
+        const xmlDeclMatch = content.match(/^(\s*<\?xml[^?]*\?>\s*)/i)
+        const xmlDecl = xmlDeclMatch ? xmlDeclMatch[1] : ''
+        let contentForParsing = content.replace(/^\s*<\?xml[^?]*\?>\s*/i, '')
+        contentForParsing = contentForParsing.replace(/^\s*<!DOCTYPE[^>]*>\s*/i, '')
+
+        const doc = parser.parseFromString(contentForParsing, 'text/html')
+
+        // Apply all fixes to the parsed DOM
+        this.applyDOMFixes(doc, fixes)
+
+        // Serialize and restore XML declaration
+        content = new XMLSerializer().serializeToString(doc)
+        fixes.push(`Fixed malformed markup in ${filename}`)
+        modified = true
+      } else {
+        // Well-formed XHTML - use regex-based fixes to preserve structure
+        const originalContent = content
+
+        // Remove epub: namespace declaration from html tag
+        content = content.replace(/\s+xmlns:epub="[^"]*"/gi, '')
+
+        // Remove epub:type attributes
+        content = content.replace(/\s+epub:type="[^"]*"/gi, '')
+
+        // Remove epub:prefix attributes
+        content = content.replace(/\s+epub:prefix="[^"]*"/gi, '')
+
+        // Remove xml:lang from html tag
+        content = content.replace(/(<html[^>]*)\s+xml:lang="[^"]*"/gi, '$1')
+
+        // Remove lang from html tag
+        content = content.replace(/(<html[^>]*)\s+lang="[^"]*"/gi, '$1')
+
+        // Remove role attributes
+        content = content.replace(/\s+role="[^"]*"/gi, '')
+
+        // Remove body ID attributes with UUID-style hashes (long IDs 20+ chars with dashes)
+        // Preserves legitimate short IDs like "chapter-1"
+        content = content.replace(/(<body[^>]*)\s+id="[a-zA-Z0-9]+-[a-zA-Z0-9-]{15,}"/gi, '$1')
+
+        // Convert <b> to <span class="...bold"> preserving existing classes
+        // Use negative lookahead to avoid matching <body, <br, etc.
+        content = content.replace(/<b(?![a-z])(\s+class="([^"]*)")?([^>]*)>([\s\S]*?)<\/b>/gi, (match, classAttr, existingClass, rest, inner) => {
+          const classes = existingClass ? existingClass + ' bold' : 'bold'
+          return `<span class="${classes}"${rest}>${inner}</span>`
+        })
+
+        // Convert <strong> to <span class="...bold">
+        content = content.replace(/<strong(\s+class="([^"]*)")?([^>]*)>([\s\S]*?)<\/strong>/gi, (match, classAttr, existingClass, rest, inner) => {
+          const classes = existingClass ? existingClass + ' bold' : 'bold'
+          return `<span class="${classes}"${rest}>${inner}</span>`
+        })
+
+        // Convert <i> to <span class="...italic">
+        // Use negative lookahead to avoid matching <img, <input, etc.
+        content = content.replace(/<i(?![a-z])(\s+class="([^"]*)")?([^>]*)>([\s\S]*?)<\/i>/gi, (match, classAttr, existingClass, rest, inner) => {
+          const classes = existingClass ? existingClass + ' italic' : 'italic'
+          return `<span class="${classes}"${rest}>${inner}</span>`
+        })
+
+        // Convert <em> to <span class="...italic">
+        content = content.replace(/<em(?![a-z])(\s+class="([^"]*)")?([^>]*)>([\s\S]*?)<\/em>/gi, (match, classAttr, existingClass, rest, inner) => {
+          const classes = existingClass ? existingClass + ' italic' : 'italic'
+          return `<span class="${classes}"${rest}>${inner}</span>`
+        })
+
+        // Remove script tags
+        const scriptMatches = content.match(/<script[\s\S]*?<\/script>/gi)
+        if (scriptMatches) {
+          content = content.replace(/<script[\s\S]*?<\/script>/gi, '')
+          fixes.push(`Removed ${scriptMatches.length} <script> tag(s) from ${filename}`)
+        }
+
+        // Remove stray img tags (no src)
+        content = content.replace(/<img(?![^>]*\ssrc=)[^>]*\/?>/gi, '')
+
+        // Remove empty alt attributes (alt="" causes Kindle E21018 error)
+        // Calibre removes these entirely
+        content = content.replace(/\s*alt=""\s*/gi, ' ')
+
+        // Remove data-AmznRemoved attributes (cause parsing errors)
+        content = content.replace(/\s*data-AmznRemoved[^=]*="[^"]*"/gi, '')
+
+        if (content !== originalContent) {
+          modified = true
+          // Count what we fixed
+          if (originalContent.includes('epub:')) fixes.push(`Removed epub: attributes from ${filename}`)
+          if (originalContent.includes('xml:lang=') || /\slang="/.test(originalContent)) fixes.push(`Removed lang attributes from ${filename}`)
+          if (originalContent.includes('role="')) fixes.push(`Removed role attributes from ${filename}`)
+          if (/<b[\s>]/i.test(originalContent) || /<strong[\s>]/i.test(originalContent) ||
+              /<i[\s>]/i.test(originalContent) || /<em[\s>]/i.test(originalContent)) {
+            fixes.push(`Converted <b>/<i> tags to <span> in ${filename}`)
+          }
+        }
+      }
+
+      if (modified) {
+        this.files[filename] = content
+        fixes.forEach(f => {
+          if (!this.fixedProblems.includes(f)) this.fixedProblems.push(f)
+        })
+      }
+    }
+  }
+
+  // Helper: apply fixes to a parsed DOM (used for malformed files)
+  applyDOMFixes(doc, fixes) {
+    // Strip scripts
+    const scripts = doc.querySelectorAll('script')
+    scripts.forEach(el => el.remove())
+
+    // Remove stray images
+    const strayImages = doc.querySelectorAll('img:not([src]), img[src=""]')
+    strayImages.forEach(el => el.remove())
+
+    // Remove empty alt attributes (causes E21018)
+    doc.querySelectorAll('img[alt=""]').forEach(el => el.removeAttribute('alt'))
+
+    // Remove data-AmznRemoved attributes (causes kindlegen rejection)
+    doc.querySelectorAll('*').forEach(el => {
+      Array.from(el.attributes).forEach(attr => {
+        if (attr.name.toLowerCase().startsWith('data-amznremoved')) {
+          el.removeAttribute(attr.name)
+        }
+      })
+    })
+
+    // Remove epub: attributes
+    doc.querySelectorAll('*').forEach(el => {
+      ['epub:type', 'epub:prefix', 'xmlns:epub'].forEach(attr => {
+        if (el.hasAttribute(attr)) el.removeAttribute(attr)
+      })
+    })
+
+    // Convert b/i/strong/em to span
+    const tagMap = { 'B': 'bold', 'STRONG': 'bold', 'I': 'italic', 'EM': 'italic' }
+    for (const [tagName, className] of Object.entries(tagMap)) {
+      Array.from(doc.getElementsByTagName(tagName)).forEach(el => {
+        const span = doc.createElement('span')
+        const classes = el.className ? el.className + ' ' + className : className
+        span.className = classes
+        span.innerHTML = el.innerHTML
+        el.parentNode.replaceChild(span, el)
+      })
+    }
+
+    // Remove body ID with UUID-style hashes (20+ chars)
+    const body = doc.querySelector('body')
+    if (body && body.id && body.id.includes('-') && body.id.length > 20) {
+      body.removeAttribute('id')
+    }
+
+    // Remove role attributes
+    doc.querySelectorAll('[role]').forEach(el => el.removeAttribute('role'))
+
+    // Remove lang attributes
+    const html = doc.querySelector('html')
+    if (html) {
+      html.removeAttribute('xml:lang')
+      html.removeAttribute('lang')
+    }
+  }
+
+  // Clean up OPF metadata - remove problematic elements
+  cleanOPFMetadata() {
+    const opfFilename = this.getOPFFilename()
+    if (!opfFilename || !(opfFilename in this.files)) {
+      return
+    }
+
+    const parser = new DOMParser()
+    const opf = parser.parseFromString(this.files[opfFilename], 'application/xml')
+
+    if (opf.querySelector('parsererror')) {
+      return
+    }
+
+    let modified = false
+
+    // Remove primary-writing-mode meta (Amazon doesn't need it)
+    const metas = opf.querySelectorAll('meta[name="primary-writing-mode"], meta[content="horizontal-lr"], meta[content="vertical-rl"]')
+    metas.forEach(meta => {
+      if (meta.getAttribute('name') === 'primary-writing-mode' ||
+          meta.getAttribute('content') === 'horizontal-lr' ||
+          meta.getAttribute('content') === 'vertical-rl') {
+        meta.remove()
+        modified = true
+      }
+    })
+
+    if (modified) {
+      this.files[opfFilename] = new XMLSerializer().serializeToString(opf)
+      this.fixedProblems.push('Removed primary-writing-mode from OPF')
+    }
+  }
+
+  // Add CSS rules for bold/italic spans if not present
+  addBoldItalicCSS() {
+    const cssRules = `
+/* Added by Kindle EPUB Fix for bold/italic span support */
+.bold { font-weight: bold; }
+.italic { font-style: italic; }
+`
+    // Find CSS files and check if rules already exist
+    for (const filename in this.files) {
+      if (filename.endsWith('.css')) {
+        const content = this.files[filename]
+        if (!content.includes('.bold') && !content.includes('.italic')) {
+          this.files[filename] = content + cssRules
+          this.fixedProblems.push(`Added .bold/.italic CSS rules to ${filename}`)
+          return // Only add to first CSS file
+        }
+      }
+    }
+  }
+
   async readEPUB(blob) {
     const reader = new zip.ZipReader(new zip.BlobReader(blob))
     this.entries = await reader.getEntries()
@@ -288,10 +774,23 @@ async function processEPUB (inputBlob, name) {
     const epub = new EPUBBook()
     await epub.readEPUB(inputBlob)
 
-    // Run fixing procedure
-    epub.fixBodyIdLink()
+    // Run fixing procedure (order matters!)
+
+    // 1. Metadata fixes (OPF)
+    epub.fixUniqueIdentifier()
     epub.fixBookLanguage()
-    epub.fixStrayIMG()
+    epub.cleanOPFMetadata()
+
+    // 2. Navigation fixes (NCX)
+    epub.fixNCXPlayOrder()
+    epub.normalizeNCXUnicode()
+
+    // 3. Content fixes (HTML/XHTML)
+    epub.fixBodyIdLink()
+    epub.reserializeHTML()  // DOM round-trip with script/image cleanup, epub: attrs, b/i conversion
+    epub.addBoldItalicCSS() // Add CSS rules for converted bold/italic spans
+
+    // 4. Final encoding fix (must be last for HTML files)
     epub.fixEncoding()
 
     // Write EPUB


### PR DESCRIPTION
This changeset builds on top of https://github.com/innocenat/kindle-epub-fix/pull/25 and adds fixes to 2 additional issues:

- `Error E20006: There are more than one title defined in OPF metadata. But none of them is refined with "title-type" as "main" title. Refer http://idpf.org/epub/30/spec/epub30-publications.html#sec-opf-dctitle for more info.`
- `Error E21011: The book title was not set. Please set the title before generating the mobi.`